### PR TITLE
팔로우/언팔로우 후 홈 피드에 반영 안되던 버그 수정

### DIFF
--- a/app-watch/src/main/java/io/foundy/hanstargramwatch/view/explore/ExploreActivity.kt
+++ b/app-watch/src/main/java/io/foundy/hanstargramwatch/view/explore/ExploreActivity.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -20,6 +22,8 @@ class ExploreActivity : ViewBindingActivity<ActivityExploreBinding>() {
 
     private val viewModel: ExploreViewModel by viewModels()
 
+    private lateinit var launcher: ActivityResultLauncher<Intent>
+
     override val bindingInflater: (LayoutInflater) -> ActivityExploreBinding
         get() = ActivityExploreBinding::inflate
 
@@ -34,6 +38,12 @@ class ExploreActivity : ViewBindingActivity<ActivityExploreBinding>() {
 
         val adapter = UserAdapter(onClickUser = ::onClickUser)
         initRecyclerView(adapter)
+
+        launcher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (it.resultCode == RESULT_OK) {
+                setResult(RESULT_OK)
+            }
+        }
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -64,6 +74,6 @@ class ExploreActivity : ViewBindingActivity<ActivityExploreBinding>() {
 
     private fun startProfileActivity(userUuid: String) {
         val intent = ProfileActivity.getIntent(this, userUuid)
-        startActivity(intent)
+        launcher.launch(intent)
     }
 }

--- a/app-watch/src/main/java/io/foundy/hanstargramwatch/view/home/HomeActivity.kt
+++ b/app-watch/src/main/java/io/foundy/hanstargramwatch/view/home/HomeActivity.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
@@ -23,6 +25,8 @@ import kotlinx.coroutines.launch
 class HomeActivity : ViewBindingActivity<ActivityHomeBinding>() {
 
     private val viewModel: HomeViewModel by viewModels()
+
+    private lateinit var launcher: ActivityResultLauncher<Intent>
 
     override val bindingInflater: (LayoutInflater) -> ActivityHomeBinding
         get() = ActivityHomeBinding::inflate
@@ -44,6 +48,12 @@ class HomeActivity : ViewBindingActivity<ActivityHomeBinding>() {
 
         binding.exploreButton.setOnClickListener {
             startExploreActivity()
+        }
+
+        launcher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (it.resultCode == RESULT_OK) {
+                adapter.refresh()
+            }
         }
 
         lifecycleScope.launch {
@@ -95,11 +105,11 @@ class HomeActivity : ViewBindingActivity<ActivityHomeBinding>() {
 
     private fun startProfileActivity(userUuid: String) {
         val intent = ProfileActivity.getIntent(this, userUuid)
-        startActivity(intent)
+        launcher.launch(intent)
     }
 
     private fun startExploreActivity() {
         val intent = ExploreActivity.getIntent(this)
-        startActivity(intent)
+        launcher.launch(intent)
     }
 }

--- a/app-watch/src/main/java/io/foundy/hanstargramwatch/view/profile/ProfileActivity.kt
+++ b/app-watch/src/main/java/io/foundy/hanstargramwatch/view/profile/ProfileActivity.kt
@@ -43,6 +43,7 @@ class ProfileActivity : ViewBindingActivity<ActivityProfileBinding>() {
 
         binding.followButton.setOnClickListener {
             viewModel.toggleFollow()
+            setResult(RESULT_OK)
         }
 
         lifecycleScope.launch {

--- a/app/src/main/java/io/foundy/hanstargram/view/home/postlist/PostListFragment.kt
+++ b/app/src/main/java/io/foundy/hanstargram/view/home/postlist/PostListFragment.kt
@@ -11,6 +11,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.LinearLayoutCompat
 import androidx.core.view.isVisible
+import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -28,7 +29,10 @@ import io.foundy.hanstargram.view.common.registerObserverForScrollToTop
 import io.foundy.hanstargram.view.common.setListeners
 import io.foundy.hanstargram.view.posting.PostingActivity
 import io.foundy.hanstargram.view.profile.ProfileActivity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class PostListFragment(
     private val toolbarTitle: String? = null,
@@ -67,6 +71,14 @@ class PostListFragment(
         launcher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             if (it.resultCode == RESULT_OK) {
                 adapter.refresh()
+            }
+        }
+        setFragmentResultListener("refreshPosts") { _, _ ->
+            viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Default) {
+                delay(300)
+                withContext(Dispatchers.Main) {
+                    adapter.refresh()
+                }
             }
         }
 
@@ -176,7 +188,7 @@ class PostListFragment(
 
     private fun startProfileActivity(userUuid: String) {
         val intent = ProfileActivity.getIntent(requireContext(), userUuid)
-        startActivity(intent)
+        launcher.launch(intent)
     }
 
     private fun startPostingActivity() {

--- a/app/src/main/java/io/foundy/hanstargram/view/home/search/SearchFragment.kt
+++ b/app/src/main/java/io/foundy/hanstargram/view/home/search/SearchFragment.kt
@@ -1,14 +1,20 @@
 package io.foundy.hanstargram.view.home.search
 
+import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -24,7 +30,10 @@ import io.foundy.hanstargram.view.profile.ProfileActivity
 import kotlinx.coroutines.launch
 
 class SearchFragment : ViewBindingFragment<FragmentSearchBinding>() {
+
     private val viewModel: SearchViewModel by viewModels()
+
+    private lateinit var launcher: ActivityResultLauncher<Intent>
 
     override val bindingInflater: (LayoutInflater, ViewGroup?, Boolean) -> FragmentSearchBinding
         get() = FragmentSearchBinding::inflate
@@ -37,6 +46,12 @@ class SearchFragment : ViewBindingFragment<FragmentSearchBinding>() {
 
         if (binding.queryInput.requestFocus()) {
             showSoftKeyboard()
+        }
+
+        launcher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (it.resultCode == Activity.RESULT_OK) {
+                setFragmentResult("refreshPosts", bundleOf())
+            }
         }
 
         val debounceTextChange = debounce(300L, viewModel.viewModelScope, viewModel::searchUser)
@@ -98,6 +113,6 @@ class SearchFragment : ViewBindingFragment<FragmentSearchBinding>() {
 
     private fun onClickUser(uiState: SearchItemUiState) {
         val intent = ProfileActivity.getIntent(requireContext(), uiState.uuid)
-        startActivity(intent)
+        launcher.launch(intent)
     }
 }

--- a/app/src/main/java/io/foundy/hanstargram/view/profile/ProfileFragment.kt
+++ b/app/src/main/java/io/foundy/hanstargram/view/profile/ProfileFragment.kt
@@ -1,5 +1,6 @@
 package io.foundy.hanstargram.view.profile
 
+import android.app.Activity.RESULT_OK
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -53,6 +54,7 @@ class ProfileFragment(
                 changeToProfileEditFragment()
             } else {
                 viewModel.toggleFollow()
+                requireActivity().setResult(RESULT_OK)
             }
         }
 


### PR DESCRIPTION
Fixes #52 

- UserRepository에서 followingList를 캐시하도록하여 동적으로 팔로잉 목록을 접근할 수 있도록 수정했습니다.
- 액티비티 혹은 프래그먼트 pop시 이전 화면에서 adapter를 리프레시 하도록 수정했습니다.


https://user-images.githubusercontent.com/57604817/201464972-092c1916-1832-4b4e-a428-4c325ca80202.mov

