### PR TITLE
Firestore `whereIn` 함수의 제약으로 발생한 문제 해결

### DIFF
--- a/data/src/main/java/io/foundy/data/repository/UserRepository.kt
+++ b/data/src/main/java/io/foundy/data/repository/UserRepository.kt
@@ -13,6 +13,7 @@ import com.google.firebase.storage.ktx.storage
 import io.foundy.data.model.FollowDto
 import io.foundy.data.model.UserDto
 import io.foundy.data.source.UserPagingSource
+import io.foundy.data.source.UserSearchPagingSource
 import io.foundy.domain.model.UserDetail
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
@@ -22,7 +23,7 @@ import java.util.*
 
 object UserRepository {
 
-    private const val PAGE_SIZE = 30
+    const val PAGE_SIZE = 30
 
     private var followingList: MutableList<FollowDto>? = null
 
@@ -68,10 +69,10 @@ object UserRepository {
             if (followeeUuids.isEmpty()) {
                 return emptyFlow()
             }
-            val followingUsersQuery = userCollection.whereIn("uuid", followeeUuids)
+            val userReferences = followeeUuids.map { userCollection.document(it) }
 
             return Pager(PagingConfig(pageSize = PAGE_SIZE)) {
-                UserPagingSource(userQuery = followingUsersQuery)
+                UserPagingSource(userReferences = userReferences)
             }.flow
         } catch (e: Exception) {
             throw e
@@ -92,10 +93,10 @@ object UserRepository {
             if (followerUuids.isEmpty()) {
                 return emptyFlow()
             }
-            val followersQuery = userCollection.whereIn("uuid", followerUuids)
+            val userReferences = followerUuids.map { userCollection.document(it) }
 
             return Pager(PagingConfig(pageSize = PAGE_SIZE)) {
-                UserPagingSource(userQuery = followersQuery)
+                UserPagingSource(userReferences = userReferences)
             }.flow
         } catch (e: Exception) {
             throw e
@@ -214,7 +215,7 @@ object UserRepository {
         }
 
         return Pager(PagingConfig(pageSize = PAGE_SIZE)) {
-            UserPagingSource(userQuery = queryUsersByName)
+            UserSearchPagingSource(userQuery = queryUsersByName)
         }.flow
     }
 

--- a/data/src/main/java/io/foundy/data/source/UserPagingSource.kt
+++ b/data/src/main/java/io/foundy/data/source/UserPagingSource.kt
@@ -2,40 +2,33 @@ package io.foundy.data.source
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
-import com.google.firebase.firestore.Query
-import com.google.firebase.firestore.QuerySnapshot
-import com.google.firebase.firestore.ktx.toObjects
+import com.google.firebase.firestore.DocumentReference
 import io.foundy.data.model.UserDto
+import io.foundy.data.repository.UserRepository
 import kotlinx.coroutines.tasks.await
 
 class UserPagingSource(
-    private val userQuery: Query
-) : PagingSource<QuerySnapshot, UserDto>() {
+    private val userReferences: List<DocumentReference>
+) : PagingSource<Int, UserDto>() {
 
-    override fun getRefreshKey(state: PagingState<QuerySnapshot, UserDto>): QuerySnapshot? {
+    override fun getRefreshKey(state: PagingState<Int, UserDto>): Int? {
         return null
     }
 
     override suspend fun load(
-        params: LoadParams<QuerySnapshot>
-    ): LoadResult<QuerySnapshot, UserDto> {
+        params: LoadParams<Int>
+    ): LoadResult<Int, UserDto> {
         return try {
-            val currentPage = params.key ?: userQuery.get().await()
-            if (currentPage.isEmpty) {
-                return LoadResult.Page(
-                    data = emptyList(),
-                    prevKey = null,
-                    nextKey = null
-                )
+            val currentPage = params.key ?: 0
+            val nextPage = minOf(currentPage + UserRepository.PAGE_SIZE, userReferences.size)
+            val userDtoList = userReferences.subList(currentPage, nextPage).map {
+                it.get().await().toObject(UserDto::class.java)!!
             }
-            val lastVisiblePost = currentPage.documents[currentPage.size() - 1]
-            val nextPage = userQuery.startAfter(lastVisiblePost).get().await()
-            val userDto = currentPage.toObjects<UserDto>()
 
             LoadResult.Page(
-                data = userDto,
+                data = userDtoList,
                 prevKey = null,
-                nextKey = nextPage
+                nextKey = if (nextPage == userReferences.size) null else nextPage
             )
         } catch (e: Exception) {
             LoadResult.Error(e)

--- a/data/src/main/java/io/foundy/data/source/UserSearchPagingSource.kt
+++ b/data/src/main/java/io/foundy/data/source/UserSearchPagingSource.kt
@@ -1,0 +1,44 @@
+package io.foundy.data.source
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.firestore.ktx.toObjects
+import io.foundy.data.model.UserDto
+import kotlinx.coroutines.tasks.await
+
+class UserSearchPagingSource(
+    private val userQuery: Query
+) : PagingSource<QuerySnapshot, UserDto>() {
+
+    override fun getRefreshKey(state: PagingState<QuerySnapshot, UserDto>): QuerySnapshot? {
+        return null
+    }
+
+    override suspend fun load(
+        params: LoadParams<QuerySnapshot>
+    ): LoadResult<QuerySnapshot, UserDto> {
+        return try {
+            val currentPage = params.key ?: userQuery.get().await()
+            if (currentPage.isEmpty) {
+                return LoadResult.Page(
+                    data = emptyList(),
+                    prevKey = null,
+                    nextKey = null
+                )
+            }
+            val lastVisiblePost = currentPage.documents[currentPage.size() - 1]
+            val nextPage = userQuery.startAfter(lastVisiblePost).get().await()
+            val userDto = currentPage.toObjects<UserDto>()
+
+            LoadResult.Page(
+                data = userDto,
+                prevKey = null,
+                nextKey = nextPage
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #79 

- 팔로우한 사람들 + 나의 게시글을 불러오는 것의 경우 일단 모든 게시글 목록을 firestore에 요청하고 client 측에서 filter를 하는 것으로 임시 해결했습니다. 좋은 방법은 아니니 괜찮은 방법을 찾아봐야합니다.(생각해본 방법 중 하나는 `whereEqualsTo`를 여러번 반복하여 돌려 팔로우한 사람과 나의 모든 게시글 목록을 한 번에 가져온 뒤 시간순으로 정렬하여 보이는 것입니다.)
- 팔로우, 팔로잉 회원 목록의 경우 회원 uuid와 users의 document uid가 같은 점을 이용하여 해결했습니다.

https://user-images.githubusercontent.com/57604817/203252935-d130287b-c9c9-4a2e-ac21-11b5f891c83c.mov

