### PR TITLE
ViewHolder에서 회원 프로필 이미지 없을때 `Glide.fallback` 함수 호출하도록 수정

### DIFF
--- a/app-watch/src/main/java/io/foundy/hanstargramwatch/view/explore/UserViewHolder.kt
+++ b/app-watch/src/main/java/io/foundy/hanstargramwatch/view/explore/UserViewHolder.kt
@@ -4,6 +4,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.ktx.storage
+import io.foundy.hanstargramwatch.R
 import io.foundy.hanstargramwatch.databinding.ItemUserBinding
 
 class UserViewHolder(
@@ -16,9 +17,9 @@ class UserViewHolder(
     fun bind(uiState: UserItemUiState) = with(binding) {
         val glide = Glide.with(root)
 
-        uiState.profileImageUrl?.let { imageUrl ->
-            glide.load(storageReference.child(imageUrl)).into(profileImage)
-        }
+        glide.load(uiState.profileImageUrl?.let { storageReference.child(it) })
+            .fallback(R.drawable.ic_baseline_person_24)
+            .into(profileImage)
 
         name.text = uiState.name
 

--- a/app/src/main/java/io/foundy/hanstargram/view/userlist/UserViewHolder.kt
+++ b/app/src/main/java/io/foundy/hanstargram/view/userlist/UserViewHolder.kt
@@ -3,6 +3,7 @@ package io.foundy.hanstargram.view.userlist
 import androidx.recyclerview.widget.RecyclerView
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.ktx.storage
+import io.foundy.hanstargram.R
 import io.foundy.hanstargram.databinding.ItemUserBinding
 
 class UserViewHolder(
@@ -15,9 +16,9 @@ class UserViewHolder(
     fun bind(uiState: UserItemUiState) = with(binding) {
         val glide = com.bumptech.glide.Glide.with(root)
 
-        uiState.profileImageUrl?.let { imageUrl ->
-            glide.load(storageReference.child(imageUrl)).into(profileImage)
-        }
+        glide.load(uiState.profileImageUrl?.let { storageReference.child(it) })
+            .fallback(R.drawable.ic_baseline_person_24)
+            .into(profileImage)
 
         name.text = uiState.name
 


### PR DESCRIPTION
Fixes #82 


https://user-images.githubusercontent.com/57604817/203267271-90688b79-a4b6-4cf5-b41e-fcbf122fb362.mov

